### PR TITLE
feat(sync): Add content type breakdown to sync progress UI

### DIFF
--- a/ipodrocks-js/src/__tests__/sync-core.test.ts
+++ b/ipodrocks-js/src/__tests__/sync-core.test.ts
@@ -970,3 +970,222 @@ describe("runSync artwork behavior", () => {
     expect(fs.existsSync(path.join(devicePath, "OrphanArtist"))).toBe(false);
   });
 });
+
+describe("SyncProgress contentType tracking", () => {
+  it("emits progress events with contentType for music when tracks need syncing", async () => {
+    const events: Array<{ event: string; contentType?: string }> = [];
+    const onProgress = (e: { event: string; contentType?: string }) => events.push(e);
+
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "sync-contenttype-test-"));
+    const devicePath = path.join(tmpRoot, "device", "Music");
+    const libraryPath = path.join(tmpRoot, "library");
+    fs.mkdirSync(devicePath, { recursive: true });
+    fs.mkdirSync(path.join(libraryPath, "Artist", "Album"), { recursive: true });
+
+    const trackPath = path.join(libraryPath, "Artist", "Album", "track.mp3");
+    fs.writeFileSync(trackPath, "audio");
+
+    const libraryTracks: Record<string, Record<string, unknown>> = {
+      [trackPath]: { artist: "Artist", album: "Album", fileSize: 5 },
+    };
+    const deviceFilesMap: Record<string, { file_size: number }> = {};
+
+    const profile = {
+      name: "Test",
+      mountPath: path.dirname(devicePath),
+      musicFolder: "Music",
+      podcastFolder: "Podcasts",
+      audiobookFolder: "Audiobooks",
+      playlistFolder: "Playlists",
+      modelId: null,
+      defaultCodecConfigId: null,
+      description: null,
+      lastSyncDate: null,
+      totalSyncedItems: 0,
+      lastSyncCount: 0,
+      defaultTransferModeId: 1,
+      overrideBitrate: null,
+      overrideQuality: null,
+      overrideBits: null,
+      partialSyncEnabled: false,
+      sourceLibraryType: "primary" as const,
+      shadowLibraryId: null,
+      transferModeName: null,
+      codecConfigName: "DIRECT COPY",
+      codecConfigBitrate: null,
+      codecConfigQuality: null,
+      codecConfigBits: null,
+      codecName: "DIRECT COPY",
+      modelName: null,
+      modelInternalValue: null,
+    };
+    const device = new Device(profile as never);
+
+    await runSync(
+      device,
+      libraryTracks,
+      "DIRECT COPY",
+      "music",
+      devicePath,
+      deviceFilesMap,
+      { extraTrackPolicy: "keep", skipAlbumArtwork: true, progressCallback: onProgress }
+    );
+
+    try {
+      const copyEvents = events.filter((e) => e.event === "copy");
+      expect(copyEvents.length).toBe(1);
+      copyEvents.forEach((e) => {
+        expect(e.contentType).toBe("music");
+      });
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("emits progress events with artwork contentType when artwork is copied", async () => {
+    const events: Array<{ event: string; contentType?: string }> = [];
+    const onProgress = (e: { event: string; contentType?: string }) => events.push(e);
+
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "sync-artwork-type-test-"));
+    const devicePath = path.join(tmpRoot, "device", "Music");
+    const libraryPath = path.join(tmpRoot, "library");
+    fs.mkdirSync(devicePath, { recursive: true });
+    fs.mkdirSync(path.join(libraryPath, "Artist", "Album"), { recursive: true });
+
+    const trackPath = path.join(libraryPath, "Artist", "Album", "track.mp3");
+    const coverPath = path.join(libraryPath, "Artist", "Album", "cover.jpg");
+    fs.writeFileSync(trackPath, "audio");
+    fs.writeFileSync(coverPath, "jpeg");
+
+    const deviceTrackPath = path.join(devicePath, "Artist", "Album", "track.mp3");
+    fs.mkdirSync(path.dirname(deviceTrackPath), { recursive: true });
+    fs.writeFileSync(deviceTrackPath, "audio");
+
+    const libraryTracks: Record<string, Record<string, unknown>> = {
+      [trackPath]: { artist: "Artist", album: "Album", fileSize: 5 },
+    };
+    const deviceFilesMap: Record<string, { file_size: number }> = {
+      [deviceTrackPath]: { file_size: 5 },
+    };
+
+    const profile = {
+      name: "Test",
+      mountPath: path.dirname(devicePath),
+      musicFolder: "Music",
+      podcastFolder: "Podcasts",
+      audiobookFolder: "Audiobooks",
+      playlistFolder: "Playlists",
+      modelId: null,
+      defaultCodecConfigId: null,
+      description: null,
+      lastSyncDate: null,
+      totalSyncedItems: 0,
+      lastSyncCount: 0,
+      defaultTransferModeId: 1,
+      overrideBitrate: null,
+      overrideQuality: null,
+      overrideBits: null,
+      partialSyncEnabled: false,
+      sourceLibraryType: "primary" as const,
+      shadowLibraryId: null,
+      transferModeName: null,
+      codecConfigName: "DIRECT COPY",
+      codecConfigBitrate: null,
+      codecConfigQuality: null,
+      codecConfigBits: null,
+      codecName: "DIRECT COPY",
+      modelName: null,
+      modelInternalValue: null,
+    };
+    const device = new Device(profile as never);
+
+    await runSync(
+      device,
+      libraryTracks,
+      "DIRECT COPY",
+      "music",
+      devicePath,
+      deviceFilesMap,
+      { extraTrackPolicy: "keep", skipAlbumArtwork: false, progressCallback: onProgress }
+    );
+
+    try {
+      const artworkEvents = events.filter((e) => e.event === "copy" && e.contentType === "artwork");
+      expect(artworkEvents.length).toBe(1);
+      expect(artworkEvents[0].contentType).toBe("artwork");
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("emits analysis event with content type context", async () => {
+    const events: Array<{ event: string; contentType?: string }> = [];
+    const onProgress = (e: { event: string; contentType?: string }) => events.push(e);
+
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "sync-analysis-test-"));
+    const devicePath = path.join(tmpRoot, "device", "Music");
+    const libraryPath = path.join(tmpRoot, "library");
+    fs.mkdirSync(devicePath, { recursive: true });
+    fs.mkdirSync(path.join(libraryPath, "Artist", "Album"), { recursive: true });
+
+    const trackPath = path.join(libraryPath, "Artist", "Album", "track.mp3");
+    fs.writeFileSync(trackPath, "audio");
+
+    const libraryTracks: Record<string, Record<string, unknown>> = {
+      [trackPath]: { artist: "Artist", album: "Album", fileSize: 5 },
+    };
+    const deviceFilesMap: Record<string, { file_size: number }> = {};
+
+    const profile = {
+      name: "Test",
+      mountPath: path.dirname(devicePath),
+      musicFolder: "Music",
+      podcastFolder: "Podcasts",
+      audiobookFolder: "Audiobooks",
+      playlistFolder: "Playlists",
+      modelId: null,
+      defaultCodecConfigId: null,
+      description: null,
+      lastSyncDate: null,
+      totalSyncedItems: 0,
+      lastSyncCount: 0,
+      defaultTransferModeId: 1,
+      overrideBitrate: null,
+      overrideQuality: null,
+      overrideBits: null,
+      partialSyncEnabled: false,
+      sourceLibraryType: "primary" as const,
+      shadowLibraryId: null,
+      transferModeName: null,
+      codecConfigName: "DIRECT COPY",
+      codecConfigBitrate: null,
+      codecConfigQuality: null,
+      codecConfigBits: null,
+      codecName: "DIRECT COPY",
+      modelName: null,
+      modelInternalValue: null,
+    };
+    const device = new Device(profile as never);
+
+    await runSync(
+      device,
+      libraryTracks,
+      "DIRECT COPY",
+      "music",
+      devicePath,
+      deviceFilesMap,
+      { extraTrackPolicy: "keep", skipAlbumArtwork: true, progressCallback: onProgress }
+    );
+
+    try {
+      const logEvents = events.filter((e) => e.event === "log");
+      const musicLogFound = logEvents.some((e) => 
+        typeof e.contentType === 'undefined' || e.contentType === "music"
+      );
+      expect(logEvents.length).toBeGreaterThan(0);
+      expect(musicLogFound).toBe(true);
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/ipodrocks-js/src/__tests__/sync.test.tsx
+++ b/ipodrocks-js/src/__tests__/sync.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { SyncPanel } from "../renderer/components/panels/SyncPanel";
+import { SyncProgressModal, SyncCompleteResult } from "../renderer/components/modals/SyncProgressModal";
 
 vi.mock("../renderer/ipc/api", () => ({
   getDevices: vi.fn().mockResolvedValue([]),
@@ -9,6 +10,9 @@ vi.mock("../renderer/ipc/api", () => ({
   getPlaylistTracks: vi.fn().mockResolvedValue([]),
   getShadowLibraries: vi.fn().mockResolvedValue([]),
   getLibraryStats: vi.fn().mockResolvedValue({ totalTracks: 0 }),
+  startSync: vi.fn().mockResolvedValue({ synced: 0, errors: 0 }),
+  cancelSync: vi.fn().mockResolvedValue(undefined),
+  onSyncProgress: vi.fn(() => () => {}),
 }));
 
 describe("SyncPanel", () => {
@@ -23,5 +27,25 @@ describe("SyncPanel", () => {
     const checkbox = screen.getByLabelText("Not syncing album artwork");
     expect(checkbox).toBeInTheDocument();
     expect(checkbox).not.toBeChecked();
+  });
+});
+
+describe("SyncCompleteResult interface", () => {
+  it("includes skippedBreakdown with all content types", () => {
+    const result: SyncCompleteResult = {
+      synced: 2765,
+      skipped: 260,
+      errors: 0,
+      status: "success",
+      skippedBreakdown: {
+        music: 0,
+        podcast: 0,
+        audiobook: 0,
+        artwork: 260,
+        playlist: 0,
+      },
+    };
+    expect(result.skippedBreakdown.artwork).toBe(260);
+    expect(result.skippedBreakdown.music).toBe(0);
   });
 });

--- a/ipodrocks-js/src/renderer/components/modals/SyncProgressModal.tsx
+++ b/ipodrocks-js/src/renderer/components/modals/SyncProgressModal.tsx
@@ -18,6 +18,13 @@ export interface SyncCompleteResult {
   skipped: number;
   errors: number;
   status: "success" | "error" | "warning";
+  skippedBreakdown: {
+    music: number;
+    podcast: number;
+    audiobook: number;
+    artwork: number;
+    playlist: number;
+  };
 }
 
 interface SyncProgressModalProps {
@@ -53,6 +60,12 @@ export function SyncProgressModal({
   const [totalItems, setTotalItems] = useState(0);
   const [processedItems, setProcessedItems] = useState(0);
   const [copiedItems, setCopiedItems] = useState(0);
+  const [skippedByType, setSkippedByType] = useState({
+    music: 0, podcast: 0, audiobook: 0, artwork: 0, playlist: 0,
+  });
+  const [copiedByType, setCopiedByType] = useState({
+    music: 0, podcast: 0, audiobook: 0, artwork: 0, playlist: 0,
+  });
   const [finished, setFinished] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [cancelled, setCancelled] = useState(false);
@@ -93,8 +106,18 @@ export function SyncProgressModal({
     if (p.event === "copy") {
       setProcessedItems((n) => n + 1);
       const status = String(p.status);
+      const contentType = (p.contentType as string) || "unknown";
       if (status === "copied" || status === "converted") {
         setCopiedItems((n) => n + 1);
+        setCopiedByType((prev) => {
+          const key = contentType as keyof typeof prev;
+          return key in prev ? { ...prev, [key]: prev[key] + 1 } : prev;
+        });
+      } else if (status === "skipped") {
+        setSkippedByType((prev) => {
+          const key = contentType as keyof typeof prev;
+          return key in prev ? { ...prev, [key]: prev[key] + 1 } : prev;
+        });
       }
       setRecentItems((prev) => {
         const next = [...prev, { id: ++itemIdRef.current, path: p.path, event: p.event, status: p.status }];
@@ -134,6 +157,8 @@ export function SyncProgressModal({
     setTotalItems(0);
     setProcessedItems(0);
     setCopiedItems(0);
+    setSkippedByType({ music: 0, podcast: 0, audiobook: 0, artwork: 0, playlist: 0 });
+    setCopiedByType({ music: 0, podcast: 0, audiobook: 0, artwork: 0, playlist: 0 });
     setFinished(false);
     setError(null);
     setCancelled(false);
@@ -160,11 +185,13 @@ export function SyncProgressModal({
         }
         const synced = result?.synced ?? 0;
         const errors = result?.errors ?? 0;
+        const totalSkipped = processedItems - copiedItems;
         onCompleteRef.current?.({
           synced,
-          skipped: 0,
+          skipped: totalSkipped,
           errors: isCancelled ? 0 : errors || (errMsg ? 1 : 0),
           status: isCancelled ? "warning" : errors > 0 ? (synced > 0 ? "warning" : "error") : "success",
+          skippedBreakdown: skippedByType,
         });
       })
       .catch((e) => {
@@ -181,6 +208,7 @@ export function SyncProgressModal({
           skipped: 0,
           errors: isCancelled ? 0 : 1,
           status: "error",
+          skippedBreakdown: skippedByType,
         });
       })
       .finally(() => {
@@ -331,6 +359,17 @@ export function SyncProgressModal({
                 <p className="text-xs text-muted-foreground">Skipped</p>
               </div>
             </div>
+            {(skippedByType.music > 0 || skippedByType.podcast > 0 || skippedByType.audiobook > 0 || skippedByType.artwork > 0 || skippedByType.playlist > 0) && (
+              <div className="mt-2 text-xs text-muted-foreground text-center">
+                Skipped: {[
+                  skippedByType.music > 0 && `${skippedByType.music} songs`,
+                  skippedByType.podcast > 0 && `${skippedByType.podcast} podcasts`,
+                  skippedByType.audiobook > 0 && `${skippedByType.audiobook} audiobooks`,
+                  skippedByType.artwork > 0 && `${skippedByType.artwork} artwork`,
+                  skippedByType.playlist > 0 && `${skippedByType.playlist} playlists`,
+                ].filter(Boolean).join(", ")}
+              </div>
+            )}
             {cancelled && (
               <p className="mt-2 text-center text-xs text-warning">Sync was cancelled</p>
             )}


### PR DESCRIPTION
Track skipped and copied items by content type (music, podcast, audiobook, artwork, playlist) in SyncProgressModal.

Previously the UI showed only aggregate counts making it impossible to distinguish skipped songs from skipped artwork. Now the completion summary shows a breakdown like 'Skipped: 260 artwork'.

Changes:
- Add skippedBreakdown to SyncCompleteResult interface
- Add skippedByType and copiedByType state trackers
- Update handleProgress to track contentType from progress events
- Show breakdown in completion summary when items were skipped
- Add tests for content type tracking in progress events

Fixes confusion when syncing 1:1 copies where artwork files that already exist on device were reported as skipped tracks.