### PR TITLE
Fix review findings from PR #96 (artwork, Unicode paths, progress)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixes
+
+- **Album artwork is generated on network/SMB libraries again** — On shares that report filenames in a different Unicode form than iPodRocks stores (SAMBA/SMB, some Linux mounts), cover generation silently found nothing and no `cover.jpg` was written, even though the tracks themselves synced fine. Artwork lookup now resolves the on-disk name the same way track copying does.
+- **Tracks with Unicode names are no longer reported as missing during sync** — The pre-copy existence check compared the stored name rather than the on-disk name, so accented or non-Latin filenames on those same shares could be flagged "missing" and skipped even though they were present.
+- **Changing a device's artwork size now takes effect on existing albums** — Covers were only regenerated when the source image changed, so switching Artwork size (200/300/500/750 px) appeared to do nothing until an album's art was edited. Existing covers are now regenerated when they no longer match the selected size, while genuinely small source art is still left alone.
+- **Sync progress no longer overshoots** — Generated covers were counted as processed without being added to the total, so the progress bar could read past 100% (e.g. "48/40") and appear finished while tracks were still copying.
+- **Cancelling a sync stops artwork generation immediately** — A cancel during cover conversion was mistaken for a conversion failure, so iPodRocks fell back to copying the original image and kept writing covers after the user asked it to stop.
+- **More trash folders are excluded from scanning** — Deleted copies inside a bare `Trash` folder (the freedesktop.org location) or a NAS recycle bin (`#recycle` on Synology, `@Recycle` on QNAP) were still indexed as real tracks. Folders that merely contain the word, like "Trash Talk", are still scanned as normal.
+- **Artwork conversion can't hang a sync** — A malformed or extremely large image made ffmpeg run unbounded; cover conversion now gives up after 20 seconds and moves on.
+- **Duplicate reports handle unusual filenames** — Paths containing a newline no longer garble the "Duplicates detected" list.
+
+### Improvements
+
+- **Rocksy can find duplicate files** — Asking "do I have duplicate songs?" now uses a dedicated read-only tool that lists byte-identical copies and their paths. It deletes nothing; removing a copy stays your decision.
+
 ## [2.1.0] — 2026-07
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 - **Artwork conversion can't hang a sync** — A malformed or extremely large image made ffmpeg run unbounded; cover conversion now gives up after 20 seconds and moves on.
 - **Duplicate reports handle unusual filenames** — Paths containing a newline no longer garble the "Duplicates detected" list.
 
+### Changes
+
+- **Artwork failures now fail the sync — and say so plainly** — Album artwork problems were previously advisory and left the sync reporting success, so a device could finish with no cover art and no indication anything went wrong. A sync with artwork failures is now reported as failed, but labelled unambiguously: the status reads "Failed — album artwork only", artwork failures are counted in their own "Artwork Errors" column separate from "Song Errors", and the summary states that cover art was affected while your song files copied fine. The sync log lists the specific album folders involved. Playlists are still written, since they depend on track data rather than artwork.
+
 ### Improvements
 
 - **Rocksy can find duplicate files** — Asking "do I have duplicate songs?" now uses a dedicated read-only tool that lists byte-identical copies and their paths. It deletes nothing; removing a copy stays your decision.

--- a/ipodrocks-js/src/__tests__/assistant-tools.test.ts
+++ b/ipodrocks-js/src/__tests__/assistant-tools.test.ts
@@ -436,3 +436,88 @@ describe("playlist_repair (write-safe)", () => {
     expect(getToolByName("playlist_repair")!.summarize({ playlist_id: 9 })).toContain("9");
   });
 });
+
+describe("library_find_duplicates (read)", () => {
+  const DUP_SQL_MATCH = "GROUP_CONCAT";
+
+  /** Build a db mock whose duplicate query returns the given concat rows. */
+  function makeDupDb(rows: { file_hash: string; paths: string; n: number }[]) {
+    return {
+      prepare: (sql: string) => ({
+        all: () => (sql.includes(DUP_SQL_MATCH) ? rows : []),
+        get: () => null,
+        run: vi.fn(),
+      }),
+    } as unknown as AiToolContext["db"];
+  }
+
+  it("is classified as a read tool so it runs inline without a confirm gate", () => {
+    expect(getToolByName("library_find_duplicates")!.kind).toBe("read");
+  });
+
+  it("is registered in the tool definitions Rocksy sees", () => {
+    const names = buildToolDefinitions().map((d) => d.function.name);
+    expect(names).toContain("library_find_duplicates");
+  });
+
+  it("reports duplicate groups with their paths", async () => {
+    const ctx = makeCtx({
+      db: makeDupDb([
+        { file_hash: "h1", paths: "/music/a.mp3\x1f/music/b.mp3", n: 2 },
+      ]),
+    });
+    const result = (await getToolByName("library_find_duplicates")!.run({}, ctx)) as {
+      duplicateGroups: number;
+      totalDuplicateFiles: number;
+      groups: Array<{ copies: number; paths: string[] }>;
+    };
+
+    expect(result.duplicateGroups).toBe(1);
+    expect(result.totalDuplicateFiles).toBe(2);
+    expect(result.groups[0].paths).toEqual(["/music/a.mp3", "/music/b.mp3"]);
+  });
+
+  it("reports cleanly when there are no duplicates", async () => {
+    const ctx = makeCtx({ db: makeDupDb([]) });
+    const result = (await getToolByName("library_find_duplicates")!.run({}, ctx)) as {
+      duplicateGroups: number;
+      groups: unknown[];
+      note: string;
+    };
+    expect(result.duplicateGroups).toBe(0);
+    expect(result.groups).toEqual([]);
+    expect(result.note).toContain("No byte-identical duplicates");
+  });
+
+  it("caps the number of returned groups", async () => {
+    const rows = Array.from({ length: 40 }, (_, i) => ({
+      file_hash: `h${i}`,
+      paths: `/music/${i}-a.mp3\x1f/music/${i}-b.mp3`,
+      n: 2,
+    }));
+    const ctx = makeCtx({ db: makeDupDb(rows) });
+    const result = (await getToolByName("library_find_duplicates")!.run({ limit: 5 }, ctx)) as {
+      duplicateGroups: number;
+      returned: number;
+      groups: unknown[];
+    };
+
+    // The full count is still reported so Rocksy can say how many exist.
+    expect(result.duplicateGroups).toBe(40);
+    expect(result.returned).toBe(5);
+    expect(result.groups).toHaveLength(5);
+  });
+
+  it("falls back to the default limit for a nonsense limit", async () => {
+    const rows = Array.from({ length: 30 }, (_, i) => ({
+      file_hash: `h${i}`,
+      paths: `/music/${i}.mp3\x1f/music/${i}-copy.mp3`,
+      n: 2,
+    }));
+    const ctx = makeCtx({ db: makeDupDb(rows) });
+    const result = (await getToolByName("library_find_duplicates")!.run({ limit: -3 }, ctx)) as {
+      returned: number;
+    };
+    expect(result.returned).toBe(25);
+  });
+});

--- a/ipodrocks-js/src/__tests__/behaviors/artwork-failure-reporting.test.ts
+++ b/ipodrocks-js/src/__tests__/behaviors/artwork-failure-reporting.test.ts
@@ -1,0 +1,129 @@
+/**
+ * @vitest-environment node
+ *
+ * Album-artwork failures must be reported as failures, but attributed to cover
+ * art rather than to song data. This exercises the real generator against a
+ * destination that cannot be created, so the failure is genuine rather than
+ * mocked, and checks the failed album folders are named for the sync log.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { spawnSync } from "child_process";
+
+import { installElectronMock } from "../harness/ipc-harness";
+
+installElectronMock();
+
+import { getFfmpegPath } from "../../main/utils/ffmpeg-path";
+import { copyAlbumArtworkToDevice } from "../../main/sync/sync-core";
+
+interface Event {
+  event: string;
+  path?: string;
+  status?: string;
+  contentType?: string;
+  message?: string;
+}
+
+function ffmpegAvailable(): boolean {
+  try {
+    return spawnSync(getFfmpegPath(), ["-version"], { encoding: "utf8" }).status === 0;
+  } catch {
+    return false;
+  }
+}
+
+const canRun = ffmpegAvailable();
+
+describe.skipIf(!canRun)("album artwork failure reporting", () => {
+  let workDir: string;
+
+  beforeAll(() => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), "rbx-artfail-"));
+  });
+  afterAll(() => {
+    try {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  /** Seed an album folder with a track placeholder and real cover art. */
+  function seedAlbum(root: string, artist: string, album: string): string {
+    const dir = path.join(root, artist, album);
+    fs.mkdirSync(dir, { recursive: true });
+    const trackPath = path.join(dir, "01 Track.mp3");
+    fs.writeFileSync(trackPath, Buffer.from("placeholder-audio"));
+    const r = spawnSync(
+      getFfmpegPath(),
+      [
+        "-y", "-f", "lavfi", "-i", "color=c=green:s=400x400",
+        "-frames:v", "1", path.join(dir, "cover.png"),
+      ],
+      { encoding: "utf8" }
+    );
+    expect(r.status).toBe(0);
+    return trackPath;
+  }
+
+  it("counts a failed cover and names the album folder", async () => {
+    const libRoot = path.join(workDir, "lib-fail");
+    const deviceDir = path.join(workDir, "device-fail");
+    fs.mkdirSync(deviceDir, { recursive: true });
+
+    const trackPath = seedAlbum(libRoot, "Blocked Artist", "Blocked Album");
+
+    // Plant a FILE where the album directory must be created, so the generator
+    // cannot write its cover and genuinely fails.
+    fs.mkdirSync(path.join(deviceDir, "Blocked Artist"), { recursive: true });
+    fs.writeFileSync(path.join(deviceDir, "Blocked Artist", "Blocked Album"), "not a directory");
+
+    const events: Event[] = [];
+    const result = await copyAlbumArtworkToDevice(
+      deviceDir,
+      "music",
+      { [trackPath]: { artist: "Blocked Artist", album: "Blocked Album" } },
+      undefined,
+      (e) => events.push(e as Event),
+      undefined,
+      false,
+      300
+    );
+
+    expect(result.errors).toBe(1);
+    expect(result.copied).toBe(0);
+    expect(result.failedAlbums).toHaveLength(1);
+    expect(result.failedAlbums[0]).toContain("Blocked Album");
+
+    // The failure is reported as artwork, never as track content.
+    const errorEvents = events.filter((e) => e.event === "copy" && e.status === "error");
+    expect(errorEvents).toHaveLength(1);
+    expect(errorEvents[0].contentType).toBe("artwork");
+  });
+
+  it("reports no failures when every cover is generated", async () => {
+    const libRoot = path.join(workDir, "lib-ok");
+    const deviceDir = path.join(workDir, "device-ok");
+    fs.mkdirSync(deviceDir, { recursive: true });
+
+    const trackPath = seedAlbum(libRoot, "Fine Artist", "Fine Album");
+
+    const result = await copyAlbumArtworkToDevice(
+      deviceDir,
+      "music",
+      { [trackPath]: { artist: "Fine Artist", album: "Fine Album" } },
+      undefined,
+      undefined,
+      undefined,
+      false,
+      300
+    );
+
+    expect(result.copied).toBe(1);
+    expect(result.errors).toBe(0);
+    expect(result.failedAlbums).toEqual([]);
+  });
+});

--- a/ipodrocks-js/src/__tests__/behaviors/artwork-progress-accounting.test.ts
+++ b/ipodrocks-js/src/__tests__/behaviors/artwork-progress-accounting.test.ts
@@ -1,0 +1,136 @@
+/**
+ * @vitest-environment node
+ *
+ * The sync progress bar raises its total only on "total"/"total_add" events but
+ * advances the processed count on every "copy" event. Artwork generation must
+ * therefore announce each cover it is about to write, or the processed count
+ * overruns the total (e.g. "48/40 copied") and the bar reaches 100% while
+ * tracks are still copying.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { spawnSync } from "child_process";
+
+import { installElectronMock } from "../harness/ipc-harness";
+
+installElectronMock();
+
+import { getFfmpegPath } from "../../main/utils/ffmpeg-path";
+import { copyAlbumArtworkToDevice } from "../../main/sync/sync-core";
+import type { SyncProgressEventName } from "../../../src/shared/types";
+
+interface Event {
+  event: SyncProgressEventName;
+  path?: string;
+  status?: string;
+  contentType?: string;
+}
+
+function ffmpegAvailable(): boolean {
+  try {
+    return spawnSync(getFfmpegPath(), ["-version"], { encoding: "utf8" }).status === 0;
+  } catch {
+    return false;
+  }
+}
+
+const canRun = ffmpegAvailable();
+
+describe.skipIf(!canRun)("artwork progress accounting", () => {
+  let workDir: string;
+  let deviceDir: string;
+
+  beforeAll(() => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), "rbx-progress-"));
+    deviceDir = path.join(workDir, "device");
+    fs.mkdirSync(deviceDir, { recursive: true });
+  });
+  afterAll(() => {
+    try {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  /** Seed an album folder with a track placeholder and a cover image. */
+  function seedAlbum(artist: string, album: string): string {
+    const dir = path.join(workDir, "library", artist, album);
+    fs.mkdirSync(dir, { recursive: true });
+    const trackPath = path.join(dir, "01 Track.mp3");
+    fs.writeFileSync(trackPath, Buffer.from("placeholder-audio"));
+    const cover = path.join(dir, "cover.png");
+    const r = spawnSync(
+      getFfmpegPath(),
+      ["-y", "-f", "lavfi", "-i", "color=c=blue:s=600x600", "-frames:v", "1", cover],
+      { encoding: "utf8" }
+    );
+    expect(r.status).toBe(0);
+    return trackPath;
+  }
+
+  it("emits one total_add for every artwork copy event", async () => {
+    const tracks: Record<string, Record<string, unknown>> = {};
+    for (const album of ["Album One", "Album Two", "Album Three"]) {
+      tracks[seedAlbum("Some Artist", album)] = {
+        artist: "Some Artist",
+        album,
+      };
+    }
+
+    const events: Event[] = [];
+    const result = await copyAlbumArtworkToDevice(
+      deviceDir,
+      "music",
+      tracks,
+      undefined,
+      (e) => events.push(e as Event),
+      undefined,
+      false,
+      300
+    );
+
+    expect(result.copied).toBe(3);
+
+    const copyEvents = events.filter(
+      (e) => e.event === "copy" && e.contentType === "artwork"
+    );
+    const totalAdds = events.filter((e) => e.event === "total_add");
+
+    expect(copyEvents).toHaveLength(3);
+    // One announced item per reported item — the invariant the progress bar needs.
+    const announced = totalAdds.reduce((sum, e) => sum + Number(e.path ?? 0), 0);
+    expect(announced).toBe(copyEvents.length);
+  });
+
+  it("announces nothing when every cover is already up to date", async () => {
+    const tracks: Record<string, Record<string, unknown>> = {};
+    tracks[seedAlbum("Second Artist", "Cached Album")] = {
+      artist: "Second Artist",
+      album: "Cached Album",
+    };
+
+    const first: Event[] = [];
+    await copyAlbumArtworkToDevice(
+      deviceDir, "music", tracks, undefined,
+      (e) => first.push(e as Event), undefined, false, 300
+    );
+    expect(first.filter((e) => e.event === "total_add")).toHaveLength(1);
+
+    const second: Event[] = [];
+    const result = await copyAlbumArtworkToDevice(
+      deviceDir, "music", tracks, undefined,
+      (e) => second.push(e as Event), undefined, false, 300
+    );
+
+    expect(result.skipped).toBe(1);
+    expect(result.copied).toBe(0);
+    // A no-op artwork pass must not inflate either counter.
+    expect(second.filter((e) => e.event === "total_add")).toHaveLength(0);
+    expect(
+      second.filter((e) => e.event === "copy" && e.contentType === "artwork")
+    ).toHaveLength(0);
+  });
+});

--- a/ipodrocks-js/src/__tests__/behaviors/rockbox-artwork.test.ts
+++ b/ipodrocks-js/src/__tests__/behaviors/rockbox-artwork.test.ts
@@ -21,6 +21,7 @@ import {
   findAlbumArtSource,
   generateRockboxCover,
 } from "../../main/sync/rockbox-cover";
+import { SyncCancelled } from "../../main/sync/sync-core";
 
 function ffmpegAvailable(): boolean {
   try {
@@ -132,6 +133,61 @@ describe.skipIf(!canRun)("Rockbox cover generation", () => {
     );
     expect(result).toBe("written");
     expect(fs.readFileSync(dest).toString()).toBe("not a real image");
+  });
+
+  it("regenerates when the max dimension is raised", async () => {
+    const src = makeImage("resize-up.png", "1000x1000");
+    const dest = path.join(workDir, "AlbumF", "cover.jpg");
+    const source = { kind: "file" as const, path: src, mtimeMs: fs.statSync(src).mtimeMs };
+
+    expect(await generateRockboxCover(source, dest, { maxDim: 200 })).toBe("written");
+    expect(inspectJpeg(fs.readFileSync(dest)).width).toBeLessThanOrEqual(202);
+
+    // The source art is untouched, so an mtime-only freshness check would skip
+    // here and silently leave the cover at the old size.
+    expect(await generateRockboxCover(source, dest, { maxDim: 500 })).toBe("written");
+    const resized = inspectJpeg(fs.readFileSync(dest));
+    expect(resized.width).toBeGreaterThan(300);
+    expect(resized.width).toBeLessThanOrEqual(502);
+  });
+
+  it("regenerates when the max dimension is lowered", async () => {
+    const src = makeImage("resize-down.png", "1000x1000");
+    const dest = path.join(workDir, "AlbumG", "cover.jpg");
+    const source = { kind: "file" as const, path: src, mtimeMs: fs.statSync(src).mtimeMs };
+
+    expect(await generateRockboxCover(source, dest, { maxDim: 750 })).toBe("written");
+    expect(await generateRockboxCover(source, dest, { maxDim: 200 })).toBe("written");
+    expect(inspectJpeg(fs.readFileSync(dest)).width).toBeLessThanOrEqual(202);
+  });
+
+  it("still skips a small source that can never reach the max dimension", async () => {
+    const src = makeImage("tiny.png", "150x150");
+    const dest = path.join(workDir, "AlbumH", "cover.jpg");
+    const source = { kind: "file" as const, path: src, mtimeMs: fs.statSync(src).mtimeMs };
+
+    expect(await generateRockboxCover(source, dest, { maxDim: 300 })).toBe("written");
+    // 150px art is never upscaled, so it legitimately stays under 300px — this
+    // must not regenerate on every single sync.
+    expect(await generateRockboxCover(source, dest, { maxDim: 300 })).toBe("skipped");
+  });
+
+  it("propagates cancellation instead of falling back to a verbatim copy", async () => {
+    const src = makeImage("cancel.png", "1200x1200");
+    const dest = path.join(workDir, "AlbumI", "cover.jpg");
+    const controller = new AbortController();
+
+    const pending = generateRockboxCover(
+      { kind: "file", path: src, mtimeMs: fs.statSync(src).mtimeMs },
+      dest,
+      { maxDim: 300, signal: controller.signal }
+    );
+    controller.abort();
+
+    // ffmpeg rejects with a plain Error("Cancelled"); it must surface as
+    // SyncCancelled rather than being swallowed into the fallback copy.
+    await expect(pending).rejects.toBeInstanceOf(SyncCancelled);
+    expect(fs.existsSync(dest)).toBe(false);
   });
 
   it("prefers a folder-art file named cover/folder/front over others", async () => {

--- a/ipodrocks-js/src/__tests__/duplicate-files.test.ts
+++ b/ipodrocks-js/src/__tests__/duplicate-files.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @vitest-environment node
+ *
+ * Duplicate detection is shared by the post-scan warnings and Rocksy's
+ * `library_find_duplicates` tool, so it is tested directly against a real
+ * in-memory database.
+ *
+ * The separator matters: paths are recovered from a GROUP_CONCAT, and POSIX
+ * filenames may legally contain newlines — hence the ASCII Unit Separator.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { canRunDbTests, createTestDb, type TestDb } from "./harness/db";
+import {
+  findDuplicateFileGroups,
+  formatDuplicateWarnings,
+} from "../main/library/duplicate-files";
+
+describe.skipIf(!canRunDbTests)("findDuplicateFileGroups", () => {
+  let db: TestDb;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  function addTrack(trackPath: string, fileHash: string | null): void {
+    db.prepare(
+      "INSERT INTO tracks (path, filename, content_type, file_hash) VALUES (?, ?, 'music', ?)"
+    ).run(trackPath, trackPath.split("/").pop(), fileHash);
+  }
+
+  it("groups tracks that share a content hash", () => {
+    addTrack("/music/a/original.mp3", "hash-aaa");
+    addTrack("/music/b/copy.mp3", "hash-aaa");
+    addTrack("/music/c/unique.mp3", "hash-bbb");
+
+    const groups = findDuplicateFileGroups(db);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].fileHash).toBe("hash-aaa");
+    expect(groups[0].paths.sort()).toEqual([
+      "/music/a/original.mp3",
+      "/music/b/copy.mp3",
+    ]);
+  });
+
+  it("ignores tracks with no computed hash", () => {
+    addTrack("/music/x.mp3", null);
+    addTrack("/music/y.mp3", null);
+    addTrack("/music/z.mp3", "");
+
+    expect(findDuplicateFileGroups(db)).toEqual([]);
+  });
+
+  it("restricts results to the given folder prefix", () => {
+    addTrack("/music/rock/a.mp3", "hash-aaa");
+    addTrack("/music/rock/b.mp3", "hash-aaa");
+    addTrack("/other/jazz/a.mp3", "hash-ccc");
+    addTrack("/other/jazz/b.mp3", "hash-ccc");
+
+    expect(findDuplicateFileGroups(db, "/music/rock")).toHaveLength(1);
+    expect(findDuplicateFileGroups(db, "/other/jazz")).toHaveLength(1);
+    expect(findDuplicateFileGroups(db)).toHaveLength(2);
+  });
+
+  it("treats LIKE metacharacters in the folder prefix literally", () => {
+    addTrack("/music/100%_live/a.mp3", "hash-aaa");
+    addTrack("/music/100%_live/b.mp3", "hash-aaa");
+    addTrack("/music/1000-live/a.mp3", "hash-ddd");
+    addTrack("/music/1000-live/b.mp3", "hash-ddd");
+
+    const groups = findDuplicateFileGroups(db, "/music/100%_live");
+    expect(groups).toHaveLength(1);
+    expect(groups[0].fileHash).toBe("hash-aaa");
+  });
+
+  it("recovers paths containing newlines intact", () => {
+    addTrack("/music/weird\nname.mp3", "hash-eee");
+    addTrack("/music/plain.mp3", "hash-eee");
+
+    const groups = findDuplicateFileGroups(db);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].paths.sort()).toEqual([
+      "/music/plain.mp3",
+      "/music/weird\nname.mp3",
+    ]);
+  });
+
+  it("reports the real copy count in the warning text", () => {
+    addTrack("/music/a.mp3", "hash-fff");
+    addTrack("/music/b.mp3", "hash-fff");
+    addTrack("/music/c.mp3", "hash-fff");
+
+    const warnings = formatDuplicateWarnings(findDuplicateFileGroups(db));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("3 copies");
+    expect(warnings[0]).toContain("/music/a.mp3");
+  });
+});

--- a/ipodrocks-js/src/__tests__/image-dimensions.test.ts
+++ b/ipodrocks-js/src/__tests__/image-dimensions.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @vitest-environment node
+ *
+ * The Rockbox cover generator decides whether an existing cover.jpg still
+ * matches the requested max dimension, so the header parsers must read real
+ * JPEG/PNG dimensions and must return null (rather than a wrong guess) for
+ * anything they don't understand.
+ */
+import { describe, it, expect } from "vitest";
+
+import {
+  longestEdge,
+  readImageDimensions,
+} from "../main/utils/image-dimensions";
+
+/** Minimal PNG: signature + IHDR chunk with the given dimensions. */
+function makePng(width: number, height: number): Buffer {
+  const buf = Buffer.alloc(24);
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(buf, 0);
+  buf.writeUInt32BE(13, 8); // IHDR length
+  buf.write("IHDR", 12, "ascii");
+  buf.writeUInt32BE(width, 16);
+  buf.writeUInt32BE(height, 20);
+  return buf;
+}
+
+/**
+ * Minimal JPEG: SOI, an APPn segment of `appLength` bytes to push the frame
+ * header off offset zero, then a SOFn frame header carrying the dimensions.
+ */
+function makeJpeg(
+  width: number,
+  height: number,
+  marker = 0xc0,
+  appLength = 16
+): Buffer {
+  const parts: number[] = [0xff, 0xd8];
+  parts.push(0xff, 0xe0, (appLength >> 8) & 0xff, appLength & 0xff);
+  for (let i = 0; i < appLength - 2; i++) parts.push(0x00);
+  parts.push(0xff, marker, 0x00, 0x11, 0x08);
+  parts.push((height >> 8) & 0xff, height & 0xff);
+  parts.push((width >> 8) & 0xff, width & 0xff);
+  for (let i = 0; i < 6; i++) parts.push(0x00);
+  return Buffer.from(parts);
+}
+
+describe("readImageDimensions", () => {
+  it("reads PNG dimensions from IHDR", () => {
+    expect(readImageDimensions(makePng(1200, 800))).toEqual({
+      width: 1200,
+      height: 800,
+    });
+  });
+
+  it("reads baseline JPEG dimensions from SOF0", () => {
+    expect(readImageDimensions(makeJpeg(640, 480))).toEqual({
+      width: 640,
+      height: 480,
+    });
+  });
+
+  it("reads progressive JPEG dimensions from SOF2", () => {
+    expect(readImageDimensions(makeJpeg(300, 300, 0xc2))).toEqual({
+      width: 300,
+      height: 300,
+    });
+  });
+
+  it("skips over large leading segments to find the frame header", () => {
+    expect(readImageDimensions(makeJpeg(500, 250, 0xc0, 4096))).toEqual({
+      width: 500,
+      height: 250,
+    });
+  });
+
+  it("returns null for data that is not a supported image", () => {
+    expect(readImageDimensions(Buffer.from("not an image at all"))).toBeNull();
+    expect(readImageDimensions(Buffer.alloc(0))).toBeNull();
+  });
+
+  it("returns null for a truncated JPEG with no frame header", () => {
+    expect(readImageDimensions(Buffer.from([0xff, 0xd8, 0xff]))).toBeNull();
+  });
+});
+
+describe("longestEdge", () => {
+  it("returns the larger of width and height", () => {
+    expect(longestEdge({ width: 1200, height: 800 })).toBe(1200);
+    expect(longestEdge({ width: 300, height: 900 })).toBe(900);
+  });
+
+  it("passes null through so callers can fall back", () => {
+    expect(longestEdge(null)).toBeNull();
+  });
+});

--- a/ipodrocks-js/src/__tests__/sync-progress-modal.test.tsx
+++ b/ipodrocks-js/src/__tests__/sync-progress-modal.test.tsx
@@ -18,10 +18,16 @@ import type { SyncOptions, SyncProgress } from "@shared/types";
 // ---- Mock the renderer IPC api ----
 
 let progressCb: ((p: SyncProgress) => void) | null = null;
-let resolveStartSync: ((r: { synced?: number; errors?: number; error?: string }) => void) | null = null;
+type StartSyncResult = {
+  synced?: number;
+  errors?: number;
+  artworkErrors?: number;
+  error?: string;
+};
+let resolveStartSync: ((r: StartSyncResult) => void) | null = null;
 const startSyncMock = vi.fn(
   (_opts?: SyncOptions) =>
-    new Promise<{ synced?: number; errors?: number; error?: string }>((resolve) => {
+    new Promise<StartSyncResult>((resolve) => {
       resolveStartSync = resolve;
     }),
 );
@@ -48,7 +54,7 @@ function emit(p: Record<string, unknown>) {
   });
 }
 
-async function finishSync(result: { synced?: number; errors?: number; error?: string }) {
+async function finishSync(result: StartSyncResult) {
   await act(async () => {
     resolveStartSync?.(result);
     await Promise.resolve();
@@ -136,5 +142,97 @@ describe("SyncProgressModal completion messaging", () => {
     await waitFor(() => expect(screen.getByText("Sync was cancelled.")).toBeInTheDocument());
     expect(screen.queryByText("Nothing to sync — device up to date.")).not.toBeInTheDocument();
     expect(screen.queryByText("Processed")).not.toBeInTheDocument();
+  });
+});
+
+describe("SyncProgressModal album-artwork failures", () => {
+  beforeEach(() => {
+    progressCb = null;
+    resolveStartSync = null;
+    startSyncMock.mockClear();
+    cancelSyncMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** Drive one processed item so the summary card renders. */
+  function emitOneCopiedTrack() {
+    emit({ event: "total", path: "1" });
+    emit({ event: "copy", path: "/music/song.mp3", status: "copied", contentType: "music" });
+  }
+
+  it("names album artwork explicitly and clears song data of blame", async () => {
+    render(<SyncProgressModal open onClose={() => {}} syncOptions={SYNC_OPTIONS} />);
+    emitOneCopiedTrack();
+    await finishSync({ synced: 1, errors: 0, artworkErrors: 2 });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Album artwork failed for 2 albums/i)).toBeTruthy();
+    });
+    // The wording must not let the user think tracks were lost.
+    expect(screen.getByText(/song files copied successfully/i)).toBeTruthy();
+  });
+
+  it("uses the singular form for a single failed album", async () => {
+    render(<SyncProgressModal open onClose={() => {}} syncOptions={SYNC_OPTIONS} />);
+    emitOneCopiedTrack();
+    await finishSync({ synced: 1, errors: 0, artworkErrors: 1 });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Album artwork failed for 1 album\b/i)).toBeTruthy();
+    });
+  });
+
+  it("reports a failure status when only artwork failed", async () => {
+    const onComplete = vi.fn();
+    render(
+      <SyncProgressModal open onClose={() => {}} syncOptions={SYNC_OPTIONS} onComplete={onComplete} />
+    );
+    emitOneCopiedTrack();
+    await finishSync({ synced: 1, errors: 0, artworkErrors: 3 });
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalled());
+    expect(onComplete.mock.calls[0][0]).toMatchObject({
+      status: "error",
+      errors: 0,
+      artworkErrors: 3,
+    });
+  });
+
+  it("keeps artwork failures out of the song-error count", async () => {
+    const onComplete = vi.fn();
+    render(
+      <SyncProgressModal open onClose={() => {}} syncOptions={SYNC_OPTIONS} onComplete={onComplete} />
+    );
+    emitOneCopiedTrack();
+    await finishSync({ synced: 4, errors: 2, artworkErrors: 5 });
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalled());
+    const result = onComplete.mock.calls[0][0];
+    expect(result.errors).toBe(2);
+    expect(result.artworkErrors).toBe(5);
+  });
+
+  it("says nothing about artwork when none failed", async () => {
+    render(<SyncProgressModal open onClose={() => {}} syncOptions={SYNC_OPTIONS} />);
+    emitOneCopiedTrack();
+    await finishSync({ synced: 1, errors: 0, artworkErrors: 0 });
+
+    await waitFor(() => expect(screen.queryByText(/Album artwork failed/i)).toBeNull());
+  });
+
+  it("does not blame artwork when the sync was cancelled", async () => {
+    const onComplete = vi.fn();
+    render(
+      <SyncProgressModal open onClose={() => {}} syncOptions={SYNC_OPTIONS} onComplete={onComplete} />
+    );
+    emitOneCopiedTrack();
+    await finishSync({ synced: 1, artworkErrors: 4, error: "Sync cancelled by user." });
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalled());
+    expect(onComplete.mock.calls[0][0]).toMatchObject({ status: "warning", artworkErrors: 0 });
+    expect(screen.queryByText(/Album artwork failed/i)).toBeNull();
   });
 });

--- a/ipodrocks-js/src/__tests__/trash-directories.test.ts
+++ b/ipodrocks-js/src/__tests__/trash-directories.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @vitest-environment node
+ *
+ * Trash folders inside a scanned library must not be indexed — a deleted copy
+ * of a track would otherwise reappear as a real library track. Matching is by
+ * exact directory name so legitimate folders like "Trash Talk" keep scanning.
+ */
+import { describe, it, expect } from "vitest";
+
+import { isTrashDirectory } from "../main/utils/audio-extensions";
+
+describe("isTrashDirectory", () => {
+  it("matches macOS and Linux trash folders", () => {
+    for (const name of [".Trash", ".Trashes", ".Trash-1000", ".trash-0"]) {
+      expect(isTrashDirectory(name)).toBe(true);
+    }
+  });
+
+  it("matches the dotless freedesktop.org trash folder", () => {
+    // ~/.local/share/Trash/files/… — the spec location has no leading dot.
+    expect(isTrashDirectory("Trash")).toBe(true);
+    expect(isTrashDirectory("trash")).toBe(true);
+    expect(isTrashDirectory("Trash-1000")).toBe(true);
+  });
+
+  it("matches Windows and NAS recycle bins", () => {
+    for (const name of [
+      "$RECYCLE.BIN",
+      "$Recycle.Bin",
+      "RECYCLER",
+      "Recycled",
+      "#recycle",
+      "@Recycle",
+    ]) {
+      expect(isTrashDirectory(name)).toBe(true);
+    }
+  });
+
+  it("does not match legitimate folders that merely contain the word", () => {
+    for (const name of [
+      "Trash Talk",
+      "Trashcan Sinatras",
+      "White Trash",
+      "Recycled Air",
+      "trashy",
+    ]) {
+      expect(isTrashDirectory(name)).toBe(false);
+    }
+  });
+});

--- a/ipodrocks-js/src/main/assistant/assistantChat.ts
+++ b/ipodrocks-js/src/main/assistant/assistantChat.ts
@@ -516,6 +516,7 @@ Tool usage rules (CRITICAL):
 - User asks to remove or delete a device → call \`device_list\` first, then call \`device_remove\`.
 - User asks to change a device's album-artwork setting or cover size (e.g. "make the artwork smaller", "my iPod is slow with big covers", "turn off artwork for my iPod", "use 300px covers") → call \`device_list\` first, then \`device_update_settings\`. Recommend 300px for iPods so they stay responsive.
 - User asks to scan the library / "scan for new music" / "rescan" → call \`library_scan\`.
+- User asks about duplicates ("do I have duplicate songs?", "find duplicates", "what did the scan mean by duplicates detected?", "clean up my library") → call \`library_find_duplicates\`. It reports byte-identical copies and deletes nothing; tell the user which paths are duplicated and let them choose what to remove.
 - User asks about playlists with missing/broken songs, or "why does my playlist show wrong count", or "fix my playlist" → call \`playlist_list_broken\` first to see which playlists are affected, then call \`playlist_repair\` on the ones the user confirms (or all if they say "fix all"). Only smart playlists can be rebuilt from rules; for others, Repair removes the missing tracks.
 - NEVER say "I can't search for podcasts" or "I can't browse the internet" — you have \`podcast_search\` for exactly this purpose.
 - NEVER say "I can't sync devices" or "I don't have a sync tool" — you have \`device_sync\`.
@@ -523,6 +524,7 @@ Tool usage rules (CRITICAL):
 - NEVER say "I can't change device settings" or "I can't adjust artwork" — you have \`device_update_settings\` for album-artwork skipping and cover size.
 - NEVER say "I can't fix or repair playlists" — you have \`playlist_list_broken\` and \`playlist_repair\`.
 - NEVER say "I can't scan the library" — you have \`library_scan\`.
+- NEVER say "I can't find duplicates" or "I can't check for duplicate files" — you have \`library_find_duplicates\`.
 - NEVER tell the user to manually find an RSS feed — use \`podcast_search\` for name-based search, or \`podcast_add_by_url\` if they have a specific URL.
 - User asks to find, search, or look up a LibriVox or public-domain audiobook → call \`audiobook_search\` immediately.
 - User asks to add, subscribe to, or get a LibriVox audiobook → call \`audiobook_search\` first, then call \`audiobook_subscribe\` with the matching result. Added books appear in the Sync panel's Audiobooks list badged "Auto" and their chapters download automatically when the user syncs their device.

--- a/ipodrocks-js/src/main/assistant/tools.ts
+++ b/ipodrocks-js/src/main/assistant/tools.ts
@@ -29,6 +29,7 @@ import {
   unsubscribe as audiobookUnsubscribeFn,
 } from "../audiobooks/audiobook-subscriptions";
 import { downloadCover as downloadAudiobookCover } from "../audiobooks/audiobook-cover";
+import { findDuplicateFileGroups } from "../library/duplicate-files";
 import { logActivity } from "../activity/activity-logger";
 import { invalidateAssistantCache } from "./assistantChat";
 import {
@@ -658,6 +659,45 @@ const library_scan: AiTool = {
   },
 };
 
+const library_find_duplicates: AiTool = {
+  name: "library_find_duplicates",
+  description:
+    "Find byte-identical duplicate audio files in the library — files whose contents hash the same, stored at two or more paths. This is what a library scan reports as 'Duplicates detected'. Read-only: it reports what it finds and deletes nothing.",
+  parameters: {
+    type: "object",
+    properties: {
+      limit: {
+        type: "number",
+        description: "Max duplicate groups to return (default 25, max 200).",
+      },
+    },
+  },
+  kind: "read",
+  summarize: () => "Find duplicate (byte-identical) files in the library",
+  async run(args, ctx) {
+    const requested = args.limit === undefined ? 25 : Number(args.limit);
+    const limit =
+      Number.isFinite(requested) && requested > 0
+        ? Math.min(Math.trunc(requested), 200)
+        : 25;
+
+    const groups = findDuplicateFileGroups(ctx.db);
+    return {
+      duplicateGroups: groups.length,
+      totalDuplicateFiles: groups.reduce((sum, g) => sum + g.paths.length, 0),
+      returned: Math.min(groups.length, limit),
+      groups: groups.slice(0, limit).map((g) => ({
+        copies: g.paths.length,
+        paths: g.paths,
+      })),
+      note:
+        groups.length === 0
+          ? "No byte-identical duplicates found."
+          : "Nothing was deleted. Removing a duplicate is the user's decision — they can delete the unwanted copy on disk and rescan.",
+    };
+  },
+};
+
 const podcast_add_by_url: AiTool = {
   name: "podcast_add_by_url",
   description: "Subscribe to a podcast using an RSS feed URL or a podcast website URL. No API key required. Works for any public podcast feed.",
@@ -812,6 +852,7 @@ export const AI_TOOLS: AiTool[] = [
   device_update_settings,
   device_sync,
   library_scan,
+  library_find_duplicates,
   podcast_download_now,
   podcast_delete_episodes,
   audiobook_search,

--- a/ipodrocks-js/src/main/ipc/sync.ts
+++ b/ipodrocks-js/src/main/ipc/sync.ts
@@ -217,7 +217,8 @@ export function registerSyncHandlers(): void {
         extras: string[];
         missingFiles: string[];
         errors: number;
-      } = { status: "completed", synced: 0, removed: 0, extras: [], missingFiles: [], errors: 0 };
+        artworkErrors: number;
+      } = { status: "completed", synced: 0, removed: 0, extras: [], missingFiles: [], errors: 0, artworkErrors: 0 };
 
       const willRunMusic = Object.keys(musicLibraryTracks).length > 0;
       const willRunPodcast = Object.keys(podcastLibraryTracks).length > 0;
@@ -331,6 +332,7 @@ export function registerSyncHandlers(): void {
         result.synced += musicResult.synced;
         result.removed += musicResult.removed;
         result.errors += musicResult.errors;
+        result.artworkErrors += musicResult.artworkErrors;
         result.extras = [...result.extras, ...musicResult.extras];
         result.missingFiles = [...result.missingFiles, ...musicResult.missingFiles];
       }
@@ -359,6 +361,7 @@ export function registerSyncHandlers(): void {
         result.synced += podcastResult.synced;
         result.removed += podcastResult.removed;
         result.errors += podcastResult.errors;
+        result.artworkErrors += podcastResult.artworkErrors;
         result.extras = [...result.extras, ...podcastResult.extras];
         result.missingFiles = [...result.missingFiles, ...podcastResult.missingFiles];
       }
@@ -387,6 +390,7 @@ export function registerSyncHandlers(): void {
         result.synced += audiobookResult.synced;
         result.removed += audiobookResult.removed;
         result.errors += audiobookResult.errors;
+        result.artworkErrors += audiobookResult.artworkErrors;
         result.extras = [...result.extras, ...audiobookResult.extras];
         result.missingFiles = [...result.missingFiles, ...audiobookResult.missingFiles];
       }
@@ -457,7 +461,7 @@ export function registerSyncHandlers(): void {
         }
       }
 
-      if (result.errors > 0) result.status = "error";
+      if (result.errors > 0 || result.artworkErrors > 0) result.status = "error";
 
       const shouldWritePlaylists =
         result.errors === 0 &&

--- a/ipodrocks-js/src/main/library/duplicate-files.ts
+++ b/ipodrocks-js/src/main/library/duplicate-files.ts
@@ -1,0 +1,64 @@
+/**
+ * Byte-identical duplicate detection over the tracks table.
+ *
+ * Two tracks are duplicates when they share a content hash — that is the file
+ * itself, not its metadata (metadata-based matching used to collapse genuinely
+ * different songs on multi-disc albums). Purely diagnostic: nothing here
+ * deletes or rewrites rows; both the post-scan warnings and Rocksy's
+ * `library_find_duplicates` tool report what they find and leave the decision
+ * to the user.
+ */
+import Database from "better-sqlite3";
+
+import { escapeLike } from "../utils/sql-like";
+
+export interface DuplicateGroup {
+  /** Shared content hash of every path in the group. */
+  fileHash: string;
+  /** Two or more paths whose file contents are identical. */
+  paths: string[];
+}
+
+/**
+ * GROUP_CONCAT separator. ASCII Unit Separator rather than "\n" because POSIX
+ * filenames may legally contain newlines, which would make the split ambiguous.
+ */
+const PATH_SEPARATOR = "\x1f";
+
+/**
+ * Find groups of tracks sharing a content hash, optionally restricted to paths
+ * under `folderPrefix`. Tracks with no computed hash are ignored — an empty
+ * hash would otherwise group every unhashed file together.
+ */
+export function findDuplicateFileGroups(
+  db: Database.Database,
+  folderPrefix?: string
+): DuplicateGroup[] {
+  const where =
+    folderPrefix != null ? "AND path LIKE ? ESCAPE '\\'" : "";
+  const params = folderPrefix != null ? [escapeLike(folderPrefix) + "%"] : [];
+
+  const rows = db
+    .prepare(
+      `SELECT file_hash, GROUP_CONCAT(path, CHAR(31)) AS paths, COUNT(*) AS n
+         FROM tracks
+        WHERE file_hash IS NOT NULL AND file_hash != ''
+          ${where}
+        GROUP BY file_hash
+       HAVING n > 1`
+    )
+    .all(...params) as { file_hash: string; paths: string; n: number }[];
+
+  return rows.map((r) => ({
+    fileHash: r.file_hash,
+    paths: r.paths.split(PATH_SEPARATOR),
+  }));
+}
+
+/** Render duplicate groups as the human-readable warnings a scan reports. */
+export function formatDuplicateWarnings(groups: DuplicateGroup[]): string[] {
+  return groups.map(
+    (g) =>
+      `Duplicate file content (${g.paths.length} copies): ${g.paths.join(" | ")}`
+  );
+}

--- a/ipodrocks-js/src/main/library/library-scanner.ts
+++ b/ipodrocks-js/src/main/library/library-scanner.ts
@@ -20,11 +20,11 @@ import {
   isTrashDirectory,
 } from "../utils/audio-extensions";
 import { normalizePath } from "../utils/normalize-path";
-
-/** Escape LIKE special chars (% _ \) so folder paths are safe in LIKE patterns. */
-function escapeLike(s: string): string {
-  return s.replace(/[%_\\]/g, (c) => "\\" + c);
-}
+import { escapeLike } from "../utils/sql-like";
+import {
+  findDuplicateFileGroups,
+  formatDuplicateWarnings,
+} from "./duplicate-files";
 
 interface TrackUpsertData {
   path: string;
@@ -453,27 +453,11 @@ export class LibraryScanner {
     warnings: string[];
     duplicateFilesDetected: number;
   } {
-    const groups = this.db
-      .prepare(
-        `SELECT file_hash, GROUP_CONCAT(path, '\n') AS paths, COUNT(*) AS n
-           FROM tracks
-          WHERE path LIKE ? ESCAPE '\\'
-            AND file_hash IS NOT NULL AND file_hash != ''
-          GROUP BY file_hash
-         HAVING n > 1`
-      )
-      .all(escapeLike(folder) + "%") as {
-      file_hash: string;
-      paths: string;
-      n: number;
-    }[];
-
-    const warnings = groups.map((g) => {
-      const paths = g.paths.split("\n");
-      return `Duplicate file content (${g.n} copies): ${paths.join(" | ")}`;
-    });
-
-    return { warnings, duplicateFilesDetected: groups.length };
+    const groups = findDuplicateFileGroups(this.db, folder);
+    return {
+      warnings: formatDuplicateWarnings(groups),
+      duplicateFilesDetected: groups.length,
+    };
   }
 
   /** Remove albums, artists, genres, codecs with no referencing tracks. */

--- a/ipodrocks-js/src/main/sync/rockbox-cover.ts
+++ b/ipodrocks-js/src/main/sync/rockbox-cover.ts
@@ -17,7 +17,14 @@ import * as path from "path";
 
 import { getFfmpegPath } from "../utils/ffmpeg-path";
 import { extractEmbeddedPicture } from "../utils/embedded-art";
+import { findOnDisk } from "../utils/normalize-path";
 import {
+  longestEdge,
+  readImageDimensions,
+  readImageDimensionsFromFile,
+} from "../utils/image-dimensions";
+import {
+  isCancellationError,
   makeSafeConversionTempPath,
   moveConvertedFile,
   runLoggedSubprocess,
@@ -26,6 +33,20 @@ import { SyncCancelled } from "./sync-core";
 
 /** Default max cover dimension in px. Conservative to keep iPods responsive. */
 export const DEFAULT_COVER_MAX_DIMENSION = 300;
+
+/**
+ * Wall-clock cap for a single cover conversion. Generous for real album art;
+ * bounds the damage from a decompression-bomb image, which ffmpeg must fully
+ * decode before the `scale` filter can shrink it.
+ */
+const COVER_FFMPEG_TIMEOUT_MS = 20_000;
+
+/**
+ * ffmpeg rounds the scaled output to even dimensions, so a regenerated cover
+ * can land a pixel or two off the requested bound. Treat anything within this
+ * tolerance as matching.
+ */
+const DIMENSION_TOLERANCE = 2;
 
 /** Folder-art basenames, in preference order (any casing on disk). */
 const FOLDER_ART_BASENAMES = ["cover", "folder", "front", "album"];
@@ -46,9 +67,17 @@ export async function findAlbumArtSource(
   albumDir: string,
   firstTrackPath: string
 ): Promise<CoverSource | null> {
+  // Both arguments are derived from DB-stored (NFC) track paths, but on
+  // normalization-sensitive filesystems (SMB/SAMBA, ext4) only the on-disk
+  // form resolves — see utils/normalize-path.ts. Resolve before any I/O, or
+  // cover generation silently finds nothing on exactly the mounts that
+  // motivated the NFC scheme in the first place.
+  const diskAlbumDir = findOnDisk(albumDir);
+  const diskTrackPath = findOnDisk(firstTrackPath);
+
   let entries: fs.Dirent[];
   try {
-    entries = fs.readdirSync(albumDir, { withFileTypes: true });
+    entries = fs.readdirSync(diskAlbumDir, { withFileTypes: true });
   } catch {
     entries = [];
   }
@@ -61,7 +90,7 @@ export async function findAlbumArtSource(
   for (const base of FOLDER_ART_BASENAMES) {
     const match = images.find((name) => path.parse(name).name.toLowerCase() === base);
     if (match) {
-      const full = path.join(albumDir, match);
+      const full = path.join(diskAlbumDir, match);
       return { kind: "file", path: full, mtimeMs: safeMtime(full) };
     }
   }
@@ -70,21 +99,21 @@ export async function findAlbumArtSource(
   if (images.length > 0) {
     let best: { name: string; size: number } | null = null;
     for (const name of images) {
-      const full = path.join(albumDir, name);
+      const full = path.join(diskAlbumDir, name);
       const size = safeSize(full);
       if (!best || size > best.size) best = { name, size };
     }
     if (best) {
-      const full = path.join(albumDir, best.name);
+      const full = path.join(diskAlbumDir, best.name);
       return { kind: "file", path: full, mtimeMs: safeMtime(full) };
     }
   }
 
   // Fall back to embedded art from the first track (also covers opus/ogg
   // targets, whose transcode drops embedded pictures).
-  const picture = await extractEmbeddedPicture(firstTrackPath);
+  const picture = await extractEmbeddedPicture(diskTrackPath);
   if (picture) {
-    return { kind: "embedded", data: picture.data, mtimeMs: safeMtime(firstTrackPath) };
+    return { kind: "embedded", data: picture.data, mtimeMs: safeMtime(diskTrackPath) };
   }
   return null;
 }
@@ -134,10 +163,15 @@ export async function generateRockboxCover(
   if (opts.signal?.aborted) throw new SyncCancelled();
   const maxDim = opts.maxDim ?? DEFAULT_COVER_MAX_DIMENSION;
 
-  // Skip if the destination cover is at least as new as the source.
+  // Skip only when the destination cover is at least as new as the source AND
+  // was generated at the size currently requested. Mtime alone is not enough:
+  // changing a device's artwork_max_dimension does not touch the source art, so
+  // every already-synced cover would silently keep its old size.
   try {
     const destStat = fs.statSync(destCoverPath);
-    if (destStat.mtimeMs >= source.mtimeMs) return "skipped";
+    if (destStat.mtimeMs >= source.mtimeMs && coverMatchesMaxDim(destCoverPath, source, maxDim)) {
+      return "skipped";
+    }
   } catch {
     /* no existing cover — generate */
   }
@@ -170,7 +204,9 @@ export async function generateRockboxCover(
     const code = await runLoggedSubprocess(
       buildCoverFfmpegArgs(srcFile, tmpDest, maxDim),
       opts.log,
-      opts.signal
+      opts.signal,
+      undefined,
+      COVER_FFMPEG_TIMEOUT_MS
     );
     if (code !== 0 || !fs.existsSync(tmpDest)) {
       throw new Error(`ffmpeg exited ${code}`);
@@ -178,8 +214,13 @@ export async function generateRockboxCover(
     moveConvertedFile(tmpDest, destCoverPath);
     return "written";
   } catch (err) {
-    if (err instanceof SyncCancelled) throw err;
     safeUnlink(tmpDest);
+    if (err instanceof SyncCancelled) throw err;
+    // runLoggedSubprocess signals abort with a plain Error("Cancelled") rather
+    // than SyncCancelled (it can't import it without a cycle). Without this,
+    // cancelling mid-ffmpeg fell through to the fallback below and kept writing
+    // covers after the user asked to stop.
+    if (isCancellationError(err)) throw new SyncCancelled();
     // Fallback: copy a source file verbatim (embedded-only sources can't).
     if (source.kind === "file") {
       try {
@@ -196,6 +237,48 @@ export async function generateRockboxCover(
   } finally {
     if (scratch) safeUnlink(scratch);
   }
+}
+
+/**
+ * Does an existing cover already reflect `maxDim`?
+ *
+ * A cover larger than the bound means the setting was lowered. A cover smaller
+ * than the bound is only stale if the source actually has pixels to spare —
+ * small source art is never upscaled, so it legitimately stays under the bound
+ * forever. When dimensions can't be read (unknown format), report a match so
+ * behaviour falls back to the plain mtime check rather than regenerating on
+ * every single sync.
+ */
+function coverMatchesMaxDim(
+  destCoverPath: string,
+  source: CoverSource,
+  maxDim: number
+): boolean {
+  const destLongest = longestEdge(readImageDimensionsFromFile(destCoverPath));
+  if (destLongest == null) return true;
+
+  if (destLongest > maxDim + DIMENSION_TOLERANCE) return false;
+
+  if (destLongest < maxDim - DIMENSION_TOLERANCE) {
+    const srcLongest = sourceLongestEdge(source);
+    if (srcLongest != null && srcLongest > destLongest + DIMENSION_TOLERANCE) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/** Longest edge of the source art, or null when it can't be determined. */
+function sourceLongestEdge(source: CoverSource): number | null {
+  if (source.kind === "file") {
+    return longestEdge(readImageDimensionsFromFile(source.path));
+  }
+  const buf = Buffer.from(
+    source.data.buffer,
+    source.data.byteOffset,
+    source.data.byteLength
+  );
+  return longestEdge(readImageDimensions(buf));
 }
 
 function safeMtime(p: string): number {

--- a/ipodrocks-js/src/main/sync/sync-conversion.ts
+++ b/ipodrocks-js/src/main/sync/sync-conversion.ts
@@ -200,11 +200,22 @@ function buildProfileCommand(
 }
 
 
+/**
+ * `runLoggedSubprocess` rejects with a plain `Error("Cancelled")` on abort — it
+ * cannot construct a `SyncCancelled` without importing sync-core, which would
+ * create a module cycle. Callers must therefore recognise cancellation by
+ * message rather than by type.
+ */
+export function isCancellationError(err: unknown): boolean {
+  return err instanceof Error && err.message === "Cancelled";
+}
+
 export function runLoggedSubprocess(
   cmd: string[],
   logCallback?: (line: string) => void,
   signal?: AbortSignal,
-  env?: NodeJS.ProcessEnv
+  env?: NodeJS.ProcessEnv,
+  timeoutMs?: number
 ): Promise<number> {
   return new Promise((resolve, reject) => {
     if (signal?.aborted) {
@@ -223,11 +234,30 @@ export function runLoggedSubprocess(
       return;
     }
 
+    let timer: NodeJS.Timeout | undefined;
+
     const onAbort = (): void => {
+      if (timer) clearTimeout(timer);
       proc.kill("SIGTERM");
       reject(new Error("Cancelled"));
     };
     signal?.addEventListener("abort", onAbort, { once: true });
+
+    const cleanup = (): void => {
+      signal?.removeEventListener("abort", onAbort);
+      if (timer) clearTimeout(timer);
+    };
+
+    // Optional watchdog. A malformed or maliciously oversized input (e.g. a
+    // decompression-bomb cover image) can make ffmpeg allocate and spin for a
+    // very long time before any output filter applies, which would otherwise
+    // hang the whole sync with no way out but user cancellation.
+    if (timeoutMs != null && timeoutMs > 0) {
+      timer = setTimeout(() => {
+        proc.kill("SIGKILL");
+        logCallback?.(`Timed out after ${timeoutMs}ms: ${cmd[0]}`);
+      }, timeoutMs);
+    }
 
     const handleOutput = (data: Buffer): void => {
       const lines = data.toString("utf-8").split(/\r?\n/);
@@ -241,12 +271,12 @@ export function runLoggedSubprocess(
     proc.stderr?.on("data", handleOutput);
 
     proc.on("error", (err) => {
-      signal?.removeEventListener("abort", onAbort);
+      cleanup();
       reject(err);
     });
 
     proc.on("close", (code) => {
-      signal?.removeEventListener("abort", onAbort);
+      cleanup();
       resolve(code ?? 1);
     });
   });

--- a/ipodrocks-js/src/main/sync/sync-core.ts
+++ b/ipodrocks-js/src/main/sync/sync-core.ts
@@ -9,7 +9,8 @@ import {
   SkippedTrack,
   compareLibraries,
 } from "./name-size-sync";
-import { ConversionSettings, updateExtension, estimateConvertedSize } from "./sync-conversion";
+import { ConversionSettings, updateExtension, estimateConvertedSize, isCancellationError } from "./sync-conversion";
+import { findOnDisk } from "../utils/normalize-path";
 import {
   CopyProgress,
   CopyToDeviceOptions,
@@ -392,7 +393,7 @@ export function analyzeContentType(
       compareOpts
     );
   } catch (err) {
-    if (err instanceof Error && err.message.includes("Cancelled")) {
+    if (isCancellationError(err)) {
       throw new SyncCancelled();
     }
     throw err;
@@ -464,7 +465,12 @@ export async function copyMissingTracks(
   const existingPaths: string[] = [];
   const missingFiles: string[] = [];
   for (const tp of missingPaths) {
-    if (fs.existsSync(tp)) {
+    // Stored paths are NFC; the on-disk name may be NFD on normalization-
+    // sensitive filesystems. Probe the resolved form but keep `tp` (NFC) as the
+    // key for destination naming and progress/DB lookups — otherwise perfectly
+    // present tracks get reported as missing and never reach copyToDevice,
+    // which does its own findOnDisk.
+    if (fs.existsSync(findOnDisk(tp))) {
       existingPaths.push(tp);
     } else {
       missingFiles.push(tp);
@@ -643,8 +649,14 @@ export async function copyAlbumArtworkToDevice(
       signal: cancelSignal,
     });
 
+    // Whether a cover needs writing is only known after the skip check, so the
+    // total grows one item at a time alongside the processed count. The renderer
+    // raises totalItems only on "total"/"total_add" but advances processedItems
+    // on every "copy" event, so emitting one without the other pushes the bar
+    // past 100% (e.g. "48/40 copied").
     if (result === "written") {
       copied++;
+      progressCallback?.({ event: "total_add", path: "1" });
       progressCallback?.({
         event: "copy",
         path: destPath,
@@ -656,6 +668,7 @@ export async function copyAlbumArtworkToDevice(
       skipped++;
     } else {
       errors++;
+      progressCallback?.({ event: "total_add", path: "1" });
       progressCallback?.({
         event: "copy",
         path: sourceDir,

--- a/ipodrocks-js/src/main/sync/sync-core.ts
+++ b/ipodrocks-js/src/main/sync/sync-core.ts
@@ -589,6 +589,8 @@ export interface ArtworkSyncResult {
   skipped: number;
   errors: number;
   totalCandidates: number;
+  /** Source album folders whose cover could not be generated. */
+  failedAlbums: string[];
 }
 
 /**
@@ -610,7 +612,7 @@ export async function copyAlbumArtworkToDevice(
   maxDim: number = DEFAULT_COVER_MAX_DIMENSION
 ): Promise<ArtworkSyncResult> {
   if (Object.keys(libraryTracks).length === 0) {
-    return { copied: 0, skipped: 0, errors: 0, totalCandidates: 0 };
+    return { copied: 0, skipped: 0, errors: 0, totalCandidates: 0, failedAlbums: [] };
   }
 
   // Per album source dir: device-relative album folder + a representative track.
@@ -635,6 +637,7 @@ export async function copyAlbumArtworkToDevice(
   let copied = 0;
   let skipped = 0;
   let errors = 0;
+  const failedAlbums: string[] = [];
 
   for (const [sourceDir, { deviceRelAlbum, firstTrack }] of albums) {
     if (cancelSignal?.aborted) throw new SyncCancelled();
@@ -668,6 +671,7 @@ export async function copyAlbumArtworkToDevice(
       skipped++;
     } else {
       errors++;
+      failedAlbums.push(sourceDir);
       progressCallback?.({ event: "total_add", path: "1" });
       progressCallback?.({
         event: "copy",
@@ -679,7 +683,7 @@ export async function copyAlbumArtworkToDevice(
     }
   }
 
-  return { copied, skipped, errors, totalCandidates: albums.size };
+  return { copied, skipped, errors, totalCandidates: albums.size, failedAlbums };
 }
 
 /**
@@ -719,7 +723,7 @@ export async function copyArtworkToShadowLibrary(
   maxDim: number = DEFAULT_COVER_MAX_DIMENSION
 ): Promise<ArtworkSyncResult> {
   if (allTracks.length === 0) {
-    return { copied: 0, skipped: 0, errors: 0, totalCandidates: 0 };
+    return { copied: 0, skipped: 0, errors: 0, totalCandidates: 0, failedAlbums: [] };
   }
 
   const albums = new Map<string, { albumRel: string; firstTrack: string }>();
@@ -740,6 +744,7 @@ export async function copyArtworkToShadowLibrary(
   let copied = 0;
   let skipped = 0;
   let errors = 0;
+  const failedAlbums: string[] = [];
 
   for (const [sourceDir, { albumRel, firstTrack }] of albums) {
     if (signal?.aborted) throw new SyncCancelled();
@@ -760,10 +765,11 @@ export async function copyArtworkToShadowLibrary(
       skipped++;
     } else {
       errors++;
+      failedAlbums.push(sourceDir);
     }
   }
 
-  return { copied, skipped, errors, totalCandidates: albums.size };
+  return { copied, skipped, errors, totalCandidates: albums.size, failedAlbums };
 }
 
 export async function runSync(
@@ -782,9 +788,12 @@ export async function runSync(
   extras: string[];
   missingFiles: string[];
   errors: number;
+  /** Album-artwork failures, counted apart from track/song-data failures. */
+  artworkErrors: number;
 }> {
   const { extraTrackPolicy, progressCallback, cancelSignal, skipAlbumArtwork, artworkMaxDimension, preloadedMtimes, profileCodecExtOverride, preserveFolderStructure } =
     options;
+  let artworkErrors = 0;
 
   progressCallback?.({ event: "log", message: `Comparing library with device (${contentType})...` });
 
@@ -871,7 +880,10 @@ export async function runSync(
       preserveFolderStructure,
       artworkMaxDimension ?? DEFAULT_COVER_MAX_DIMENSION
     );
-    // Artwork problems are advisory — never fail the whole sync over them.
+    // Artwork failures are counted separately from track failures: they surface
+    // as a sync failure of their own, but must never be mistaken for missing or
+    // corrupt song data, and must not gate track-dependent steps (playlists).
+    artworkErrors = artworkResult.errors;
     if (
       artworkResult.copied > 0 ||
       artworkResult.skipped > 0 ||
@@ -885,12 +897,29 @@ export async function runSync(
         parts.push(`${artworkResult.skipped} skipped`);
       }
       if (artworkResult.errors > 0) {
-        parts.push(`${artworkResult.errors} error(s)`);
+        parts.push(`${artworkResult.errors} failed`);
       }
       progressCallback?.({
         event: "log",
         message: `Album artwork: ${parts.join(", ")}.`,
       });
+    }
+    if (artworkResult.errors > 0) {
+      progressCallback?.({
+        event: "log",
+        message:
+          `ALBUM ARTWORK FAILED for ${artworkResult.errors} album folder(s) — ` +
+          `this is cover art only, not song data.` +
+          (errors === 0
+            ? " Every song file copied successfully."
+            : ` Track problems are reported separately (${errors} song error(s)).`),
+      });
+      for (const album of artworkResult.failedAlbums) {
+        progressCallback?.({
+          event: "log",
+          message: `  Album artwork failed: ${album}`,
+        });
+      }
     }
   }
 
@@ -899,11 +928,12 @@ export async function runSync(
   }
 
   return {
-    status: errors > 0 ? "error" : "completed",
+    status: errors > 0 || artworkErrors > 0 ? "error" : "completed",
     synced,
     removed: removedCount,
     extras: extraTrackPolicy !== "remove" ? analysis.extras : [],
     missingFiles,
     errors,
+    artworkErrors,
   };
 }

--- a/ipodrocks-js/src/main/utils/audio-extensions.ts
+++ b/ipodrocks-js/src/main/utils/audio-extensions.ts
@@ -23,16 +23,28 @@ export function isMacosMetadataFile(name: string): boolean {
 // copy of a track (e.g. inside ".Trash-1000/files/…"); we must not index those
 // copies as real library tracks. Matched by EXACT directory name (not a
 // substring) so legitimate folders like "Trash Talk/" are still scanned.
+//
+// The dotless "trash" spelling matters: the freedesktop.org spec puts the user
+// trash at "~/.local/share/Trash/files/", and NAS shares add their own vendor
+// names ("#recycle" on Synology, "@Recycle" on QNAP) that appear at the root of
+// a mounted music share.
 const TRASH_DIR_NAMES = new Set([
+  "trash",
   ".trashes",
   "$recycle.bin",
+  "recycle.bin",
   "recycler",
   "recycled",
+  "#recycle",
+  "@recycle",
+  ".recycle",
 ]);
 
 export function isTrashDirectory(name: string): boolean {
   const lower = name.toLowerCase();
   // ".Trash", ".Trashes", ".Trash-1000" (Linux XDG per-uid trash)
   if (/^\.trash(es)?(-\d+)?$/.test(lower)) return true;
+  // "Trash-1000" also occurs without the leading dot on some SMB exports.
+  if (/^trash(es)?(-\d+)?$/.test(lower)) return true;
   return TRASH_DIR_NAMES.has(lower);
 }

--- a/ipodrocks-js/src/main/utils/image-dimensions.ts
+++ b/ipodrocks-js/src/main/utils/image-dimensions.ts
@@ -1,0 +1,119 @@
+/**
+ * Minimal JPEG/PNG dimension reader.
+ *
+ * The Rockbox cover generator needs to know how big an image is without pulling
+ * in an image library: it re-encodes album art to a bounded baseline JPEG, and
+ * must be able to tell whether an already-generated `cover.jpg` matches the
+ * currently requested max dimension (see sync/rockbox-cover.ts). Only the two
+ * formats we ever write or read as folder art are supported; anything else
+ * returns null and callers fall back to their previous behaviour.
+ */
+import * as fs from "fs";
+
+export interface ImageDimensions {
+  width: number;
+  height: number;
+}
+
+/**
+ * Bytes read from the head of a file when probing dimensions. A JPEG's SOF
+ * marker sits after any EXIF/ICC segments, which are comfortably under this in
+ * practice; oversized headers simply yield null.
+ */
+const HEAD_BYTES = 128 * 1024;
+
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+/** Read dimensions from an in-memory image (e.g. an embedded cover picture). */
+export function readImageDimensions(buf: Buffer): ImageDimensions | null {
+  return readPngDimensions(buf) ?? readJpegDimensions(buf);
+}
+
+/** Read dimensions from a file on disk, probing only its head. */
+export function readImageDimensionsFromFile(
+  filePath: string
+): ImageDimensions | null {
+  let fd: number | undefined;
+  try {
+    fd = fs.openSync(filePath, "r");
+    const buf = Buffer.alloc(HEAD_BYTES);
+    const read = fs.readSync(fd, buf, 0, HEAD_BYTES, 0);
+    return readImageDimensions(buf.subarray(0, read));
+  } catch {
+    return null;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        fs.closeSync(fd);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+}
+
+/** PNG stores width/height in the IHDR chunk at a fixed offset. */
+function readPngDimensions(buf: Buffer): ImageDimensions | null {
+  if (buf.length < 24) return null;
+  for (let i = 0; i < PNG_SIGNATURE.length; i++) {
+    if (buf[i] !== PNG_SIGNATURE[i]) return null;
+  }
+  if (buf.toString("ascii", 12, 16) !== "IHDR") return null;
+  const width = buf.readUInt32BE(16);
+  const height = buf.readUInt32BE(20);
+  return width > 0 && height > 0 ? { width, height } : null;
+}
+
+/**
+ * Walk JPEG segments to the first SOFn frame header, which carries the real
+ * dimensions. Handles both baseline (SOF0) and progressive (SOF2) sources.
+ */
+function readJpegDimensions(buf: Buffer): ImageDimensions | null {
+  if (buf.length < 4 || buf[0] !== 0xff || buf[1] !== 0xd8) return null;
+
+  let i = 2;
+  while (i + 3 < buf.length) {
+    if (buf[i] !== 0xff) {
+      i++;
+      continue;
+    }
+    const marker = buf[i + 1];
+    // 0xFF is a legal fill byte before the real marker.
+    if (marker === 0xff) {
+      i++;
+      continue;
+    }
+    // Standalone markers carry no length payload.
+    if (marker === 0xd8 || marker === 0x01 || (marker >= 0xd0 && marker <= 0xd7)) {
+      i += 2;
+      continue;
+    }
+    // Start of scan / end of image — frame header would have appeared already.
+    if (marker === 0xda || marker === 0xd9) return null;
+
+    const length = buf.readUInt16BE(i + 2);
+    if (length < 2) return null;
+
+    // SOFn is 0xC0-0xCF excluding DHT (0xC4), JPG (0xC8) and DAC (0xCC).
+    const isFrameHeader =
+      marker >= 0xc0 &&
+      marker <= 0xcf &&
+      marker !== 0xc4 &&
+      marker !== 0xc8 &&
+      marker !== 0xcc;
+    if (isFrameHeader) {
+      if (i + 9 >= buf.length) return null;
+      const height = buf.readUInt16BE(i + 5);
+      const width = buf.readUInt16BE(i + 7);
+      return width > 0 && height > 0 ? { width, height } : null;
+    }
+
+    i += 2 + length;
+  }
+  return null;
+}
+
+/** Longest edge of an image, or null when dimensions can't be determined. */
+export function longestEdge(dims: ImageDimensions | null): number | null {
+  return dims ? Math.max(dims.width, dims.height) : null;
+}

--- a/ipodrocks-js/src/main/utils/sql-like.ts
+++ b/ipodrocks-js/src/main/utils/sql-like.ts
@@ -1,0 +1,7 @@
+/**
+ * Escape LIKE special chars (% _ \) so folder paths are safe in LIKE patterns.
+ * Callers must pair this with an explicit `ESCAPE '\'` clause.
+ */
+export function escapeLike(s: string): string {
+  return s.replace(/[%_\\]/g, (c) => "\\" + c);
+}

--- a/ipodrocks-js/src/renderer/components/modals/SyncProgressModal.tsx
+++ b/ipodrocks-js/src/renderer/components/modals/SyncProgressModal.tsx
@@ -16,8 +16,11 @@ interface RecentItem {
 
 export interface SyncCompleteResult {
   synced: number;
-  skipped: number;
+  /** Track/song-data failures only. Album artwork is counted separately. */
   errors: number;
+  skipped: number;
+  /** Album-artwork failures. Never song data — cover art only. */
+  artworkErrors: number;
   status: "success" | "error" | "warning";
   skippedBreakdown: {
     music: number;
@@ -97,6 +100,8 @@ export function SyncProgressModal({
   const [finished, setFinished] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [cancelled, setCancelled] = useState(false);
+  /** Album-artwork failures, reported apart from song-data failures. */
+  const [artworkErrors, setArtworkErrors] = useState(0);
   const [elapsedSec, setElapsedSec] = useState(0);
 
   const listRef = useRef<HTMLDivElement>(null);
@@ -210,6 +215,7 @@ export function SyncProgressModal({
     setFinished(false);
     setError(null);
     setCancelled(false);
+    setArtworkErrors(0);
     setElapsedSec(0);
     hasReceivedTotalRef.current = false;
 
@@ -222,7 +228,7 @@ export function SyncProgressModal({
     progressUnsubRef.current = unsub;
 
     startSync(opts)
-      .then((result: { synced?: number; removed?: number; errors?: number; error?: string }) => {
+      .then((result: { synced?: number; removed?: number; errors?: number; artworkErrors?: number; error?: string }) => {
         setFinished(true);
         const errMsg = result?.error != null ? String(result.error) : "";
         const isCancelled = errMsg.toLowerCase().includes("cancelled");
@@ -233,12 +239,28 @@ export function SyncProgressModal({
         }
         const synced = result?.synced ?? 0;
         const errors = result?.errors ?? 0;
+        const artworkErrors = isCancelled ? 0 : result?.artworkErrors ?? 0;
         const totalSkipped = processedItemsRef.current - copiedItemsRef.current;
+        setArtworkErrors(artworkErrors);
+
+        // Artwork failures fail the sync, but they are cover art only — never
+        // song data — so they get their own count and their own wording.
+        const status: SyncCompleteResult["status"] = isCancelled
+          ? "warning"
+          : errors > 0
+            ? synced > 0
+              ? "warning"
+              : "error"
+            : artworkErrors > 0
+              ? "error"
+              : "success";
+
         onCompleteRef.current?.({
           synced,
           skipped: totalSkipped,
           errors: isCancelled ? 0 : errors || (errMsg ? 1 : 0),
-          status: isCancelled ? "warning" : errors > 0 ? (synced > 0 ? "warning" : "error") : "success",
+          artworkErrors,
+          status,
           skippedBreakdown: { ...skippedByTypeRef.current },
         });
       })
@@ -255,6 +277,7 @@ export function SyncProgressModal({
           synced: 0,
           skipped: 0,
           errors: isCancelled ? 0 : 1,
+          artworkErrors: 0,
           status: "error",
           skippedBreakdown: { ...skippedByTypeRef.current },
         });
@@ -420,6 +443,12 @@ export function SyncProgressModal({
                   skippedByType.playlist > 0 && `${skippedByType.playlist} playlists`,
                 ].filter(Boolean).join(", ")}
               </div>
+            )}
+            {artworkErrors > 0 && (
+              <p className="mt-2 text-center text-xs font-medium text-destructive">
+                Album artwork failed for {artworkErrors} album{artworkErrors === 1 ? "" : "s"} — cover
+                art only. Your song files copied successfully.
+              </p>
             )}
             {cancelled && (
               <p className="mt-2 text-center text-xs text-warning">Sync was cancelled</p>

--- a/ipodrocks-js/src/renderer/components/panels/SyncPanel.tsx
+++ b/ipodrocks-js/src/renderer/components/panels/SyncPanel.tsx
@@ -855,6 +855,7 @@ export function SyncPanel() {
               skipped: r.skipped,
               removed: 0,
               errors: r.errors,
+              artworkErrors: r.artworkErrors,
               status: r.status,
             });
           }}
@@ -872,15 +873,20 @@ export function SyncPanel() {
                 color: statusColors[results.status],
               }}
             >
-              {statusLabels[results.status]}
+              {/* Artwork-only failures still read as failed, but must not imply
+                  that any song data failed to copy. */}
+              {results.errors === 0 && results.artworkErrors > 0
+                ? "Failed — album artwork only"
+                : statusLabels[results.status]}
             </span>
           </div>
-          <div className="grid grid-cols-4 gap-4">
+          <div className="grid grid-cols-5 gap-4">
             {[
               { label: "Synced", value: results.synced, color: "var(--success)" },
               { label: "Skipped", value: results.skipped, color: "var(--muted-foreground)" },
               { label: "Removed", value: results.removed, color: "var(--warning)" },
-              { label: "Errors", value: results.errors, color: "var(--destructive)" },
+              { label: "Song Errors", value: results.errors, color: "var(--destructive)" },
+              { label: "Artwork Errors", value: results.artworkErrors, color: "var(--destructive)" },
             ].map((stat) => (
               <div key={stat.label} className="text-center">
                 <p className="text-xl font-bold" style={{ color: stat.color }}>
@@ -890,6 +896,16 @@ export function SyncPanel() {
               </div>
             ))}
           </div>
+          {results.artworkErrors > 0 && (
+            <p className="mt-3 text-xs text-destructive">
+              Album artwork could not be generated for {results.artworkErrors} album
+              {results.artworkErrors === 1 ? "" : "s"}. This affects cover art only —
+              {results.errors === 0
+                ? " every song file copied successfully."
+                : " see Song Errors above for track problems."}{" "}
+              Check the sync log for the album folders involved.
+            </p>
+          )}
         </Card>
       )}
     </div>

--- a/ipodrocks-js/src/renderer/stores/sync-store.ts
+++ b/ipodrocks-js/src/renderer/stores/sync-store.ts
@@ -11,7 +11,10 @@ export interface SyncResults {
   synced: number;
   skipped: number;
   removed: number;
+  /** Track/song-data failures only. */
   errors: number;
+  /** Album-artwork failures — cover art only, never song data. */
+  artworkErrors: number;
   status: "success" | "error" | "warning";
 }
 

--- a/ipodrocks-js/tests/e2e/library-scan-duplicates.test.ts
+++ b/ipodrocks-js/tests/e2e/library-scan-duplicates.test.ts
@@ -106,6 +106,34 @@ test("scan keeps distinct same-title tracks and excludes trash copies", async ()
   expect(paths.some((p) => p.includes("Trash"))).toBe(false);
 });
 
+test("scan excludes trash folders that have no leading dot", async () => {
+  const window = await launched.app.firstWindow();
+  await window.waitForLoadState("domcontentloaded");
+
+  fs.writeFileSync(path.join(seedDir, "Keeper.mp3"), Buffer.from("keeper-bytes"));
+
+  // freedesktop.org puts the user trash at "Trash/files/" with no leading dot,
+  // and NAS shares add vendor names like "#recycle" at the share root.
+  for (const trashName of ["Trash", "#recycle", "@Recycle"]) {
+    const dir = path.join(seedDir, trashName, "files");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "Deleted.mp3"), Buffer.from(`${trashName}-bytes`));
+  }
+
+  // A legitimate folder whose name merely contains "Trash" must still scan.
+  const bandDir = path.join(seedDir, "Trash Talk");
+  fs.mkdirSync(bandDir, { recursive: true });
+  fs.writeFileSync(path.join(bandDir, "Song.mp3"), Buffer.from("band-bytes"));
+
+  await scan(window);
+  const paths = await trackPaths(window);
+
+  expect(paths.some((p) => p.includes("Keeper.mp3"))).toBe(true);
+  expect(paths.some((p) => p.includes(path.join("Trash Talk", "Song.mp3")))).toBe(true);
+  expect(paths.some((p) => p.includes("Deleted.mp3"))).toBe(false);
+  expect(paths).toHaveLength(2);
+});
+
 test("scan keeps byte-identical duplicates and reports a duplicate warning", async () => {
   const window = await launched.app.firstWindow();
   await window.waitForLoadState("domcontentloaded");


### PR DESCRIPTION
Code-quality and security review of the merged PR #96 (`1c93b3c`) surfaced nine issues. All are fixed here, each with test coverage.

CI on the merge commit was green — none of these are caught by the existing suite.

## Correctness

| Issue | File |
|---|---|
| `findAlbumArtSource` did filesystem I/O on DB-stored (NFC) paths without `findOnDisk`, so cover generation silently produced nothing on the normalization-sensitive mounts (SMB/SAMBA) the NFC scheme was introduced for | `sync/rockbox-cover.ts` |
| `copyMissingTracks` pre-filtered with a bare `existsSync` on the stored path, so NFD-named files that genuinely exist were reported "missing" and never reached `copyToDevice` (which does resolve the on-disk form) | `sync/sync-core.ts` |
| Cover freshness compared mtimes only, ignoring the requested max dimension — changing a device's Artwork size left every already-synced cover at the old size | `sync/rockbox-cover.ts` |
| Artwork emitted `copy` progress events with no matching `total_add`; the renderer raises the total only on `total`/`total_add` but advances processed on every `copy`, so the bar could read "48/40" and hit 100% early | `sync/sync-core.ts` |
| `runLoggedSubprocess` rejects with a plain `Error("Cancelled")`, so `instanceof SyncCancelled` never fired — cancelling mid-conversion fell through to the fallback and kept writing covers | `sync/rockbox-cover.ts` |
| `isTrashDirectory` missed the dotless `Trash` folder (freedesktop.org location) and NAS recycle bins (`#recycle`, `@Recycle`) | `utils/audio-extensions.ts` |

The two `findOnDisk` gaps both violate the contract stated in `utils/normalize-path.ts`: *"the NFC form is used only as the database/comparison KEY. Actual filesystem I/O must use the path exactly as the OS returned it."*

Cancellation is now recognised via a shared `isCancellationError` helper, replacing the ad-hoc message match that already existed in `sync-core.ts`.

## Robustness / security

- **Cover conversion watchdog (20s).** PR #96 changed artwork sync from `copyFileSync` to decoding untrusted image bytes through ffmpeg for every album on every sync. `runLoggedSubprocess` had no timeout, so a decompression-bomb image (small file, enormous pixel dimensions) would spin unbounded — ffmpeg must fully decode before the `scale` filter applies. Only remedy was cancelling the whole sync. The timeout is opt-in per call, so existing conversion paths are unchanged.
- **Duplicate reporting separator.** Paths were recovered from a `GROUP_CONCAT` split on `"\n"`, which POSIX filenames may legally contain. Now uses the ASCII Unit Separator.

Ruled out as not exploitable, for the record: no shell in `spawn` (so no metacharacter injection), absolute-path prefixes make ffmpeg flag/protocol injection unreachable, artwork destinations are hardcoded to `cover.jpg` behind the existing path sanitizer, all SQL uses bound parameters, and `readdirSync` with `Dirent` does not follow symlinks.

## Assistant policy (CLAUDE.md)

Duplicate detection shipped in #96 as a user-facing feature (the "Duplicates detected" panel) with no corresponding Rocksy tool, which the repo's AI Assistant Tool Policy requires. Adds `library_find_duplicates` (`read` tier — reports paths, deletes nothing) plus the two `ASSISTANT_SYSTEM_PROMPT` directives, and extracts the shared query into `library/duplicate-files.ts` so the scanner and the tool use one implementation.

## Tests

- **Unit:** JPEG/PNG header parsing, duplicate grouping (including a path containing a newline, and LIKE metacharacters in the folder prefix), trash-folder matching, and the new tool.
- **Behaviour (real ffmpeg):** cover regeneration when the size is raised and lowered, small-source still skipping, cancel surfacing as `SyncCancelled`, and the progress-event invariant. The progress test was confirmed to fail without the fix.
- **E2E:** the additional trash folder names, asserting "Trash Talk" still scans.

`npx tsc --noEmit` clean; 367 unit tests and 24 E2E tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)