### PR TITLE
Fix Recent Activity card collapsing to 0px height

### DIFF
--- a/ipodrocks-js/src/renderer/components/panels/DashboardPanel.tsx
+++ b/ipodrocks-js/src/renderer/components/panels/DashboardPanel.tsx
@@ -148,7 +148,7 @@ export function DashboardPanel() {
   }, [statsPeriod]);
 
   return (
-    <div className="panel-content grid grid-cols-2 gap-5 h-full grid-rows-[auto_auto_auto_1fr]">
+    <div className="panel-content grid grid-cols-2 gap-5">
       {/* Library Stats */}
       <Card title="Library" subtitle="Collection overview">
         {!libraryReady ? (
@@ -425,13 +425,13 @@ export function DashboardPanel() {
       </Card>
 
       {/* Recent Activity */}
-      <Card title="Recent Activity" subtitle="Last 100 operations" className="col-span-2 flex flex-col min-h-0">
+      <Card title="Recent Activity" subtitle="Last 100 operations" className="col-span-2">
         {activity.length === 0 ? (
           <div className="flex items-center justify-center py-8">
             <p className="text-xs text-muted-foreground">No recent activity</p>
           </div>
         ) : (
-          <div className="flex-1 min-h-0 overflow-y-auto space-y-1.5">
+          <div className="max-h-96 overflow-y-auto space-y-1.5">
             {activity.map((entry) => (
               <ListRow key={entry.id} className="justify-between py-1.5 px-2.5 text-xs">
                 <div className="flex items-center gap-2 min-w-0">

--- a/ipodrocks-js/tests/e2e/dashboard-recent-activity.test.ts
+++ b/ipodrocks-js/tests/e2e/dashboard-recent-activity.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Playwright e2e — Dashboard "Recent Activity" card stays visible.
+ *
+ * Regression guard: the Dashboard grid used to size its last row as `1fr`
+ * inside a fixed-height (`h-full`) container, with the Recent Activity card
+ * filling that row via its own `flex-1 min-h-0 overflow-y-auto` list. Adding
+ * the Listening Stats card (a tall `auto` row) between Shadow Libraries and
+ * Recent Activity starved that `1fr` row down to near-zero — the card's
+ * title rendered, but its list of entries collapsed to ~0px height and was
+ * never visible, no matter how far the page was scrolled. The fix drops the
+ * `h-full`/`1fr` grid entirely (all rows `auto`, page scrolls naturally) and
+ * gives Recent Activity's list a fixed `max-h-96` instead of depending on
+ * leftover grid space.
+ *
+ * Run with: `npm run build && npx playwright test`
+ */
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { test, expect } from "@playwright/test";
+
+import { launchApp, type LaunchedApp } from "./electron-launcher";
+
+interface ApiWindow {
+  api: { invoke: (channel: string, ...args: unknown[]) => Promise<unknown> };
+}
+
+let launched: LaunchedApp;
+let seedDir: string;
+
+test.beforeEach(async () => {
+  seedDir = fs.mkdtempSync(path.join(os.homedir(), ".ipr-e2e-activity-"));
+  launched = await launchApp();
+});
+
+test.afterEach(async () => {
+  await launched.cleanup();
+  try {
+    fs.rmSync(seedDir, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+test("Recent Activity entries render with real, visible height after a scan", async () => {
+  const window = await launched.app.firstWindow();
+  await window.waitForLoadState("domcontentloaded");
+
+  fs.writeFileSync(path.join(seedDir, "Track.mp3"), Buffer.from("fake-audio-bytes"));
+
+  // Produces a real `library_scan` Recent Activity row.
+  await window.evaluate(
+    (folderPath) =>
+      (window as unknown as ApiWindow).api.invoke("library:scan", {
+        folders: [{ name: "E2E Activity Seed", path: folderPath, contentType: "music" }],
+      }),
+    seedDir
+  );
+
+  const dashboardNav = window
+    .locator('[data-panel="dashboard"], [data-testid="nav-dashboard"], button:has-text("Dashboard")')
+    .first();
+  await dashboardNav.click();
+
+  await expect(window.getByText("Recent Activity")).toBeVisible();
+
+  // The regression: this row used to exist in the DOM with ~0px height,
+  // which `toBeVisible()` alone does not catch (visibility passes even for
+  // a 0-height, non-zero-width box in some cases) — assert real height too.
+  const firstEntry = window.locator("text=Library scan").first();
+  await expect(firstEntry).toBeVisible();
+  const box = await firstEntry.boundingBox();
+  expect(box).not.toBeNull();
+  expect(box!.height).toBeGreaterThan(5);
+});


### PR DESCRIPTION
## Problem
The Dashboard grid sized its last row as `1fr` inside a fixed-height (`h-full`) container, with the Recent Activity card filling that row via its own `flex-1 min-h-0 overflow-y-auto` list. The Listening Stats card (a tall `auto` row, added in #109) between Shadow Libraries and Recent Activity starved that `1fr` row to near-zero — the card title rendered but its entry list collapsed to ~0px height and was never visible, no matter how far the page was scrolled.

## Fix
Drops the `h-full`/`1fr` grid entirely (all rows `auto`, page scrolls naturally) and gives Recent Activity's list a fixed `max-h-96` instead of depending on leftover grid space.

## Testing
Added `tests/e2e/dashboard-recent-activity.test.ts` per repo e2e policy: seeds a real library scan and asserts the resulting activity row has a bounding-box height > 5px, not just `toBeVisible()` (which doesn't catch a 0-height box). Verified locally: `npm run build` + `npx playwright test tests/e2e/dashboard-recent-activity.test.ts` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)